### PR TITLE
Potential fix for code scanning alert no. 34: Disabled Spring CSRF protection

### DIFF
--- a/spring-boot-starter/starter-security/src/main/java/org/eximeebpms/bpm/spring/boot/starter/security/oauth2/CamundaSpringSecurityOAuth2AutoConfiguration.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/eximeebpms/bpm/spring/boot/starter/security/oauth2/CamundaSpringSecurityOAuth2AutoConfiguration.java
@@ -137,7 +137,7 @@ public class CamundaSpringSecurityOAuth2AutoConfiguration {
         )
         .oauth2Client(Customizer.withDefaults())
         .cors(AbstractHttpConfigurer::disable)
-        .csrf(AbstractHttpConfigurer::disable);
+        .csrf(Customizer.withDefaults());
     // @formatter:on
 
     if (oAuth2Properties.getSsoLogout().isEnabled()) {


### PR DESCRIPTION
Potential fix for [https://github.com/EximeeBPMS/eximeebpms/security/code-scanning/34](https://github.com/EximeeBPMS/eximeebpms/security/code-scanning/34)

To fix the issue, CSRF protection should be enabled in the `filterChain` method. This involves removing or modifying the line `http.csrf(AbstractHttpConfigurer::disable)` to ensure CSRF protection is active. If there are specific endpoints or use cases where CSRF protection is not required, these should be explicitly excluded using Spring's `csrf().ignoringRequestMatchers(...)` configuration.

**Steps to fix:**
1. Remove the `http.csrf(AbstractHttpConfigurer::disable)` line.
2. If certain endpoints need to bypass CSRF protection (e.g., for non-browser clients), configure CSRF to ignore those endpoints explicitly.
3. Ensure the rest of the security configuration remains intact and functional.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
