### PR TITLE
Additional parameter for task filtering both with candidateGroup and candidateUser

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/eximeebpms/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/eximeebpms/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -138,6 +138,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   private String candidateGroupLike;
   private String candidateUser;
   private String candidateUserExpression;
+  private Boolean candidateUserAndGroup;
   private Boolean includeAssignedTasks;
   private String taskDefinitionKey;
   private String[] taskDefinitionKeyIn;
@@ -386,6 +387,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   @EximeeBPMSQueryParam("candidateUserExpression")
   public void setCandidateUserExpression(String candidateUserExpression) {
     this.candidateUserExpression = candidateUserExpression;
+  }
+
+  @EximeeBPMSQueryParam(value = "candidateUserAndGroup", converter = BooleanConverter.class)
+  public void setCandidateUserAndGroup(Boolean candidateUserAndGroup) {
+    this.candidateUserAndGroup = candidateUserAndGroup;
   }
 
   @EximeeBPMSQueryParam(value = "includeAssignedTasks", converter = BooleanConverter.class)
@@ -827,6 +833,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     if (assigneeNotIn != null && assigneeNotIn.length > 0) {
       query.taskAssigneeNotIn(assigneeNotIn);
     }
+    if (TRUE.equals(candidateUserAndGroup)) {
+      query.candidateUserAndGroup();
+    }
     if (candidateGroup != null) {
       query.taskCandidateGroup(candidateGroup);
     }
@@ -994,7 +1003,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
       DelegationState state = converter.convertQueryParameterToType(delegationState);
       query.taskDelegationState(state);
     }
-    if (candidateGroups != null) {
+    if (candidateGroups != null && !candidateGroups.isEmpty()) {
       query.taskCandidateGroupIn(candidateGroups);
     }
     if (candidateGroupsExpression != null) {
@@ -1241,6 +1250,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.candidateUser = taskQuery.getCandidateUser();
     dto.candidateGroup = taskQuery.getCandidateGroup();
     dto.candidateGroupLike = taskQuery.getCandidateGroupLike();
+    dto.candidateUserAndGroup = taskQuery.isCandidateUserAndGroup();
     dto.candidateGroups = taskQuery.getCandidateGroupsInternal();
     dto.includeAssignedTasks = taskQuery.isIncludeAssignedTasksInternal();
     dto.withCandidateGroups = taskQuery.isWithCandidateGroups();

--- a/engine-rest/engine-rest/src/test/java/org/eximeebpms/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/eximeebpms/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -102,6 +102,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     when(sampleTaskQuery.list()).thenReturn(mockedTasks);
     when(sampleTaskQuery.count()).thenReturn((long) mockedTasks.size());
     when(sampleTaskQuery.taskCandidateGroup(anyString())).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.candidateUserAndGroup()).thenReturn(sampleTaskQuery);
 
     when(processEngine.getTaskService().createTaskQuery()).thenReturn(sampleTaskQuery);
 
@@ -549,6 +550,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("withoutCandidateUsers", true);
     parameters.put("withoutDueDate", true);
     parameters.put("withCommentAttachmentInfo", true);
+    parameters.put("candidateUserAndGroup", true);
 
     return parameters;
   }
@@ -616,6 +618,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).withoutCandidateUsers();
     verify(mockQuery).withoutDueDate();
     verify(mockQuery).withCommentAttachmentInfo();
+    verify(mockQuery).candidateUserAndGroup();
   }
 
   @Test
@@ -2300,4 +2303,101 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     assertEquals(MockProvider.EXAMPLE_TASK_DESCRIPTION, argument.getValue().getDescription());
   }
 
+  @Test
+  public void testCandidateUserAndGroup() {
+    given()
+        .queryParam("candidateUserAndGroup", true)
+        .accept(MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(TASK_QUERY_URL);
+
+    verify(mockQuery).candidateUserAndGroup();
+  }
+
+  @Test
+  public void testNeverCandidateUserAndGroup() {
+    given()
+        .queryParam("candidateUserAndGroup", false)
+        .accept(MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(TASK_QUERY_URL);
+
+    verify(mockQuery, never()).candidateUserAndGroup();
+  }
+
+  @Test
+  public void testCandidateUserAndGroupPost() {
+    Map<String, Object> queryParameters = new HashMap<>();
+    queryParameters.put("candidateUserAndGroup", true);
+    queryParameters.put("candidateUser", "aCandidate");
+    queryParameters.put("candidateGroup", "aCandidateGroup");
+
+    given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(TASK_QUERY_URL);
+
+    InOrder inOrder = inOrder(mockQuery);
+    inOrder.verify(mockQuery).candidateUserAndGroup();
+    inOrder.verify(mockQuery).taskCandidateGroup("aCandidateGroup");
+    inOrder.verify(mockQuery).taskCandidateUser("aCandidate");
+  }
+
+  @Test
+  public void testCandidateUserAndGroupWithCandidateGroupsPost() {
+    List<String> candidateGroups = new ArrayList<>();
+    candidateGroups.add("boss");
+    candidateGroups.add("worker");
+
+    Map<String, Object> queryParameters = new HashMap<>();
+    queryParameters.put("candidateUserAndGroup", true);
+    queryParameters.put("candidateUser", "aCandidate");
+    queryParameters.put("candidateGroups", candidateGroups);
+
+    given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(TASK_QUERY_URL);
+
+    InOrder inOrder = inOrder(mockQuery);
+    inOrder.verify(mockQuery).candidateUserAndGroup();
+    inOrder.verify(mockQuery).taskCandidateUser("aCandidate");
+    inOrder.verify(mockQuery).taskCandidateGroupIn(argThat(new EqualsList(candidateGroups)));
+  }
+
+  @Test
+  public void testCandidateUserAndGroupWithCandidateGroupLikePost() {
+    Map<String, Object> queryParameters = new HashMap<>();
+    queryParameters.put("candidateUserAndGroup", true);
+    queryParameters.put("candidateUser", "aCandidate");
+    queryParameters.put("candidateGroupLike", "sales%");
+
+    given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(TASK_QUERY_URL);
+
+    InOrder inOrder = inOrder(mockQuery);
+    inOrder.verify(mockQuery).candidateUserAndGroup();
+    inOrder.verify(mockQuery).taskCandidateGroupLike("sales%");
+    inOrder.verify(mockQuery).taskCandidateUser("aCandidate");
+  }
 }

--- a/engine/src/main/java/org/eximeebpms/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/eximeebpms/bpm/engine/impl/TaskQueryImpl.java
@@ -179,6 +179,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   protected List<TaskQueryImpl> queries = new ArrayList<>(Arrays.asList(this));
   protected boolean isOrQueryActive = false;
   protected boolean withCommentAttachmentInfo;
+  protected Boolean candidateUserAndGroup;
 
   public TaskQueryImpl() {
   }
@@ -352,7 +353,8 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   @Override
   public TaskQueryImpl taskCandidateUser(String candidateUser) {
     ensureNotNull("Candidate user", candidateUser);
-    if (!isOrQueryActive) {
+
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
       if (candidateGroup != null || expressions.containsKey("taskCandidateGroup")) {
         throw new ProcessEngineException("Invalid query usage: cannot set both candidateUser and candidateGroup");
       }
@@ -370,11 +372,13 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskCandidateUserExpression(String candidateUserExpression) {
     ensureNotNull("Candidate user expression", candidateUserExpression);
 
-    if (candidateGroup != null || expressions.containsKey("taskCandidateGroup")) {
-      throw new ProcessEngineException("Invalid query usage: cannot set both candidateUser and candidateGroup");
-    }
-    if (candidateGroups != null || expressions.containsKey("taskCandidateGroupIn")) {
-      throw new ProcessEngineException("Invalid query usage: cannot set both candidateUser and candidateGroupIn");
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
+      if (candidateGroup != null || expressions.containsKey("taskCandidateGroup")) {
+        throw new ProcessEngineException("Invalid query usage: cannot set both candidateUser and candidateGroup");
+      }
+      if (candidateGroups != null || expressions.containsKey("taskCandidateGroupIn")) {
+        throw new ProcessEngineException("Invalid query usage: cannot set both candidateUser and candidateGroupIn");
+      }
     }
 
     expressions.put("taskCandidateUser", candidateUserExpression);
@@ -428,7 +432,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQueryImpl taskCandidateGroup(String candidateGroup) {
     ensureNotNull("Candidate group", candidateGroup);
 
-    if (!isOrQueryActive) {
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
       if (candidateUser != null || expressions.containsKey("taskCandidateUser")) {
         throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroup and candidateUser");
       }
@@ -443,7 +447,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskCandidateGroupExpression(String candidateGroupExpression) {
     ensureNotNull("Candidate group expression", candidateGroupExpression);
 
-    if (!isOrQueryActive) {
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
       if (candidateUser != null || expressions.containsKey("taskCandidateUser")) {
         throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroup and candidateUser");
       }
@@ -457,8 +461,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskCandidateGroupLike(String candidateGroupLike) {
     ensureNotNull("Candidate group like", candidateGroupLike);
 
-    if (!isOrQueryActive && (candidateUser != null || expressions.containsKey("taskCandidateUser"))) {
-      throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroupLike and candidateUser");
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
+      if (candidateUser != null || expressions.containsKey("taskCandidateUser")) {
+        throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroupLike and candidateUser");
+      }
     }
 
     this.candidateGroupLike = candidateGroupLike;
@@ -469,7 +475,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskCandidateGroupIn(List<String> candidateGroups) {
     ensureNotEmpty("Candidate group list", candidateGroups);
 
-    if (!isOrQueryActive) {
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
       if (candidateUser != null || expressions.containsKey("taskCandidateUser")) {
         throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroupIn and candidateUser");
       }
@@ -484,7 +490,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskCandidateGroupInExpression(String candidateGroupsExpression) {
     ensureNotEmpty("Candidate group list expression", candidateGroupsExpression);
 
-    if (!isOrQueryActive) {
+    if (!isOrQueryActive && !TRUE.equals(candidateUserAndGroup)) {
       if (candidateUser != null || expressions.containsKey("taskCandidateUser")) {
         throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroupIn and candidateUser");
       }
@@ -1118,7 +1124,33 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return this;
   }
 
+  @Override
+  public TaskQuery candidateUserAndGroup() {
+    this.candidateUserAndGroup = true;
+    return this;
+  }
+
+  public boolean isCandidateUserAndGroup() {
+    return TRUE.equals(candidateUserAndGroup);
+  }
+
   public List<String> getCandidateGroups() {
+    if (TRUE.equals(candidateUserAndGroup)) {
+      if (candidateGroup != null && candidateGroups != null) {
+        List<String> result = new ArrayList<>(candidateGroups);
+        if (!result.contains(candidateGroup)) {
+          result.add(candidateGroup);
+        }
+        return result;
+      } else if (candidateGroup != null) {
+        return Collections.singletonList(candidateGroup);
+      } else if (candidateGroups != null) {
+        return candidateGroups;
+      } else {
+        return null;
+      }
+    }
+
     if (cachedCandidateGroups != null) {
       return cachedCandidateGroups;
     }
@@ -1453,8 +1485,8 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
     resetCachedCandidateGroups();
 
-    //check if candidateGroup and candidateGroups intersect
-    if (getCandidateGroup() != null && getCandidateGroupsInternal() != null && getCandidateGroups().isEmpty()) {
+    // old intersection logic applies only to legacy behavior, not candidateUserAndGroup mode
+    if (!isCandidateUserAndGroup() && getCandidateGroup() != null && getCandidateGroupsInternal() != null && getCandidateGroups().isEmpty()) {
       return Collections.emptyList();
     }
 
@@ -1489,8 +1521,8 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
     resetCachedCandidateGroups();
 
-    //check if candidateGroup and candidateGroups intersect
-    if (getCandidateGroup() != null && getCandidateGroupsInternal() != null && getCandidateGroups().isEmpty()) {
+    // old intersection logic applies only to legacy behavior, not candidateUserAndGroup mode
+    if (!isCandidateUserAndGroup() && getCandidateGroup() != null && getCandidateGroupsInternal() != null && getCandidateGroups().isEmpty()) {
       return 0;
     }
 
@@ -1852,7 +1884,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   @Override
   public TaskQuery extend(TaskQuery extending) {
     TaskQueryImpl extendingQuery = (TaskQueryImpl) extending;
-    TaskQueryImpl extendedQuery = new TaskQueryImpl();
+    TaskQueryImpl extendedQuery = new TaskQueryImpl(commandExecutor);
 
     // only add the base query's validators to the new query;
     // this is because the extending query's validators may not be applicable to the base
@@ -1947,6 +1979,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     }
     else if (this.getDelegationState() != null) {
       extendedQuery.taskDelegationState(this.getDelegationState());
+    }
+
+    if (extendingQuery.isCandidateUserAndGroup() || this.isCandidateUserAndGroup()) {
+      extendedQuery.candidateUserAndGroup();
     }
 
     if (extendingQuery.getCandidateUser() != null) {
@@ -2089,10 +2125,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       extendedQuery.taskCreatedAfter(this.getCreateTimeAfter());
     }
 
-    if(extendingQuery.getUpdatedAfter() != null) {
+    if (extendingQuery.getUpdatedAfter() != null) {
       extendedQuery.taskUpdatedAfter(extendingQuery.getUpdatedAfter());
     }
-    else if(this.getUpdatedAfter() != null) {
+    else if (this.getUpdatedAfter() != null) {
       extendedQuery.taskUpdatedAfter(this.getUpdatedAfter());
     }
 
@@ -2116,7 +2152,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     else if (this.getKeys() != null) {
       extendedQuery.taskDefinitionKeyIn(this.getKeys());
     }
-    
+
     if (extendingQuery.getKeyNotIn() != null) {
       extendedQuery.taskDefinitionKeyNotIn(extendingQuery.getKeyNotIn());
     }

--- a/engine/src/main/java/org/eximeebpms/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/eximeebpms/bpm/engine/task/TaskQuery.java
@@ -1135,4 +1135,14 @@ public interface TaskQuery extends Query<TaskQuery, Task> {
    * it might slow down the query in case of tables having high volume of data.
    */
   TaskQuery withCommentAttachmentInfo();
+
+  /**
+   * Enables strict candidate matching for queries that define both
+   * {@link #taskCandidateUser(String)} and {@link #taskCandidateGroup(String)}.
+   *
+   * When enabled, a task matches only if it has both:
+   * - the given candidate user
+   * - the given candidate group
+   */
+  TaskQuery candidateUserAndGroup();
 }

--- a/engine/src/main/resources/org/eximeebpms/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/eximeebpms/bpm/engine/impl/mapping/entity/Task.xml
@@ -250,7 +250,7 @@
       <if test="query.isOrQueryActive">
         <bind name="JOIN_TYPE" value="'left join'" />
       </if>
-      <if test="query != null &amp;&amp; (query.candidateUser != null || query.candidateGroups != null  || query.candidateGroupLike != null || query.involvedUser != null || query.withCandidateGroups || query.withCandidateUsers)">
+      <if test="query != null &amp;&amp; (query.candidateUser != null || query.candidateGroup != null || query.candidateGroups != null || query.candidateGroupLike != null || query.involvedUser != null || query.withCandidateGroups || query.withCandidateUsers)">
         <bind name="I_JOIN" value="true" />
       </if>
       <!-- the process definition table is joined if
@@ -584,38 +584,110 @@
             <if test="query.isWithoutTenantId">
               ${queryType} RES.TENANT_ID_ is null
             </if>
-            <if test="query.candidateUser != null || query.candidateGroups != null || query.candidateGroupLike != null || query.withCandidateGroups || query.withCandidateUsers">
+            <!-- candidateUserAndGroup: strict AND semantics -->
+            <if test="query.candidateUserAndGroup and query.candidateUser != null and (query.candidateGroup != null || (query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0) || query.candidateGroupLike != null)">
+                ${queryType}
+              <trim prefixOverrides="and" prefix="(" suffix=")">
+                <if test="!query.includeAssignedTasks">
+                  and RES.ASSIGNEE_ is null
+                </if>
+
+                and EXISTS (
+                select 1
+                from ${prefix}ACT_RU_IDENTITYLINK I_USER
+                where I_USER.TASK_ID_ = RES.ID_
+                and I_USER.TYPE_ = 'candidate'
+                and I_USER.USER_ID_ = #{query.candidateUser}
+                )
+
+                <if test="query.candidateGroup != null">
+                  and EXISTS (
+                  select 1
+                  from ${prefix}ACT_RU_IDENTITYLINK I_GROUP
+                  where I_GROUP.TASK_ID_ = RES.ID_
+                  and I_GROUP.TYPE_ = 'candidate'
+                  and I_GROUP.GROUP_ID_ = #{query.candidateGroup}
+                  )
+                </if>
+
+                <if test="query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
+                  and EXISTS (
+                  select 1
+                  from ${prefix}ACT_RU_IDENTITYLINK I_GROUPS
+                  where I_GROUPS.TASK_ID_ = RES.ID_
+                  and I_GROUPS.TYPE_ = 'candidate'
+                  and I_GROUPS.GROUP_ID_ IN
+                  <foreach item="group" index="index" collection="query.candidateGroups"
+                    open="(" separator="," close=")">
+                    #{group}
+                  </foreach>
+                  )
+                </if>
+
+                <if test="query.withCandidateGroups">
+                  and EXISTS (
+                  select 1
+                  from ${prefix}ACT_RU_IDENTITYLINK I_WCG
+                  where I_WCG.TASK_ID_ = RES.ID_
+                  and I_WCG.TYPE_ = 'candidate'
+                  and I_WCG.GROUP_ID_ is not null
+                  )
+                </if>
+
+                <if test="query.withCandidateUsers">
+                  and EXISTS (
+                  select 1
+                  from ${prefix}ACT_RU_IDENTITYLINK I_WCU
+                  where I_WCU.TASK_ID_ = RES.ID_
+                  and I_WCU.TYPE_ = 'candidate'
+                  and I_WCU.USER_ID_ is not null
+                  )
+                </if>
+
+                <if test="query.candidateGroupLike != null">
+                  and EXISTS (
+                  select 1
+                  from ${prefix}ACT_RU_IDENTITYLINK I_GROUPLIKE
+                  where I_GROUPLIKE.TASK_ID_ = RES.ID_
+                  and I_GROUPLIKE.TYPE_ = 'candidate'
+                  and I_GROUPLIKE.GROUP_ID_ LIKE #{query.candidateGroupLike} ESCAPE ${escapeChar}
+                  )
+                </if>
+              </trim>
+            </if>
+
+            <!-- legacy candidate semantics: candidate user OR candidate group(s) -->
+            <if test="!query.candidateUserAndGroup and (query.candidateUser != null || query.candidateGroup != null || query.candidateGroups != null || query.candidateGroupLike != null || query.withCandidateGroups || query.withCandidateUsers)">
               ${queryType}
               <trim prefixOverrides="and" prefix="(" suffix=")">
                 <if test="!query.includeAssignedTasks">
                   and RES.ASSIGNEE_ is null
                 </if>
                 and I.TYPE_ = 'candidate'
-                <if test="query.candidateUser != null || query.candidateGroups != null || query.candidateGroupLike != null">
+
+                <if test="query.candidateUser != null || query.candidateGroup != null || query.candidateGroups != null || query.candidateGroupLike != null">
                   and
-                  (
-                  <if test="query.candidateUser != null">
-                    I.USER_ID_ = #{query.candidateUser}
-                  </if>
-                  <if test="query.candidateUser != null &amp;&amp; query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
-                    or
-                  </if>
-                  <if test="query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
-                    I.GROUP_ID_ IN
-                    <foreach item="group" index="index" collection="query.candidateGroups"
-                             open="(" separator="," close=")">
-                      #{group}
-                    </foreach>
-                  </if>
-                  <!-- If we need to add the candidateGroupsLike statement and there have been previous statements
-                   in the candidates block, then we need to add an "or" first -->
-                  <if test="query.candidateGroupLike != null &amp;&amp; (query.candidateUser != null || (query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0))">
-                    or
-                  </if>
-                  <if test="query.candidateGroupLike != null">
-                    I.GROUP_ID_ LIKE #{query.candidateGroupLike}
-                  </if>
-                  )
+                  <trim prefix="(" suffix=")" prefixOverrides="or">
+                    <if test="query.candidateUser != null">
+                      or I.USER_ID_ = #{query.candidateUser}
+                    </if>
+
+                    <if test="query.candidateGroup != null">
+                      or I.GROUP_ID_ = #{query.candidateGroup}
+                    </if>
+
+                    <if test="query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
+                      or I.GROUP_ID_ IN
+                      <foreach item="group" index="index" collection="query.candidateGroups"
+                        open="(" separator="," close=")">
+                        #{group}
+                      </foreach>
+                    </if>
+
+                    <if test="query.candidateGroupLike != null">
+                      or I.GROUP_ID_ LIKE #{query.candidateGroupLike} ESCAPE ${escapeChar}
+                    </if>
+                  </trim>
                 </if>
 
                 <if test="query.withCandidateGroups">

--- a/engine/src/test/java/org/eximeebpms/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/eximeebpms/bpm/engine/test/api/task/TaskQueryTest.java
@@ -5925,6 +5925,231 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertTrue(taskResult.hasComment());
     assertTrue(taskResult.hasAttachment());
   }
+
+  @Test
+  public void testTaskCandidateUserAndGroup() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales");
+
+    Task task2 = taskService.newTask("task2");
+    taskService.saveTask(task2);
+    taskIds.add(task2.getId());
+    taskService.addCandidateUser("task2", "demo");
+
+    Task task3 = taskService.newTask("task3");
+    taskService.saveTask(task3);
+    taskIds.add(task3.getId());
+    taskService.addCandidateGroup("task3", "sales");
+
+    Task task4 = taskService.newTask("task4");
+    taskService.saveTask(task4);
+    taskIds.add(task4.getId());
+    taskService.addCandidateUser("task4", "john");
+    taskService.addCandidateGroup("task4", "sales");
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo")
+        .taskCandidateGroup("sales")
+        .list();
+
+    // then
+    assertEquals(1, tasks.size());
+    assertEquals("task1", tasks.get(0).getId());
+  }
+
+  @Test
+  public void testTaskCandidateUserAndGroupIn() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales");
+
+    Task task2 = taskService.newTask("task2");
+    taskService.saveTask(task2);
+    taskIds.add(task2.getId());
+    taskService.addCandidateUser("task2", "demo");
+    taskService.addCandidateGroup("task2", "hr");
+
+    Task task3 = taskService.newTask("task3");
+    taskService.saveTask(task3);
+    taskIds.add(task3.getId());
+    taskService.addCandidateGroup("task3", "sales");
+
+    Task task4 = taskService.newTask("task4");
+    taskService.saveTask(task4);
+    taskIds.add(task4.getId());
+    taskService.addCandidateUser("task4", "demo");
+    taskService.addCandidateGroup("task4", "it");
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo")
+        .taskCandidateGroupIn(Arrays.asList("sales", "it"))
+        .list();
+
+    // then
+    assertEquals(2, tasks.size());
+
+    List<String> ids = tasks.stream()
+        .map(Task::getId)
+        .sorted()
+        .toList();
+
+    assertEquals(Arrays.asList("task1", "task4"), ids);
+  }
+
+  @Test
+  public void testTaskCandidateUserAndGroupLike() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales-emea");
+
+    Task task2 = taskService.newTask("task2");
+    taskService.saveTask(task2);
+    taskIds.add(task2.getId());
+    taskService.addCandidateUser("task2", "demo");
+    taskService.addCandidateGroup("task2", "hr-emea");
+
+    Task task3 = taskService.newTask("task3");
+    taskService.saveTask(task3);
+    taskIds.add(task3.getId());
+    taskService.addCandidateUser("task3", "john");
+    taskService.addCandidateGroup("task3", "sales-emea");
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo")
+        .taskCandidateGroupLike("sales%")
+        .list();
+
+    // then
+    assertEquals(1, tasks.size());
+    assertEquals("task1", tasks.get(0).getId());
+  }
+
+  @Test
+  public void testTaskCandidateUserAndGroupIncludeAssignedTasks() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    task1.setAssignee("kermit");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales");
+
+    // when
+    List<Task> tasksWithoutIncludeAssigned = taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo")
+        .taskCandidateGroup("sales")
+        .list();
+
+    List<Task> tasksWithIncludeAssigned = taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo")
+        .taskCandidateGroup("sales")
+        .includeAssignedTasks()
+        .list();
+
+    // then
+    assertEquals(0, tasksWithoutIncludeAssigned.size());
+    assertEquals(1, tasksWithIncludeAssigned.size());
+    assertEquals("task1", tasksWithIncludeAssigned.get(0).getId());
+  }
+
+  @Test
+  public void testCandidateUserAndCandidateGroupInNotAllowedWithoutFlag() {
+    assertThrows(ProcessEngineException.class, () ->
+        taskService.createTaskQuery()
+            .taskCandidateUser("demo")
+            .taskCandidateGroupIn(Arrays.asList("sales"))
+            .list()
+    );
+  }
+
+  @Test
+  public void testExtendTaskQueryWithCandidateUserAndGroup() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales");
+
+    Task task2 = taskService.newTask("task2");
+    taskService.saveTask(task2);
+    taskIds.add(task2.getId());
+    taskService.addCandidateUser("task2", "demo");
+
+    TaskQueryImpl baseQuery = (TaskQueryImpl) taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo");
+
+    TaskQueryImpl extendingQuery = (TaskQueryImpl) taskService.createTaskQuery()
+        .taskCandidateGroup("sales");
+
+    // when
+    TaskQuery extendedQuery = baseQuery.extend(extendingQuery);
+    List<Task> tasks = extendedQuery.list();
+
+    // then
+    assertEquals(1, tasks.size());
+    assertEquals("task1", tasks.get(0).getId());
+  }
+
+  @Test
+  public void testExtendTaskQueryWithCandidateUserAndGroupIn() {
+    // given
+    Task task1 = taskService.newTask("task1");
+    taskService.saveTask(task1);
+    taskIds.add(task1.getId());
+    taskService.addCandidateUser("task1", "demo");
+    taskService.addCandidateGroup("task1", "sales");
+
+    Task task2 = taskService.newTask("task2");
+    taskService.saveTask(task2);
+    taskIds.add(task2.getId());
+    taskService.addCandidateUser("task2", "demo");
+    taskService.addCandidateGroup("task2", "it");
+
+    Task task3 = taskService.newTask("task3");
+    taskService.saveTask(task3);
+    taskIds.add(task3.getId());
+    taskService.addCandidateUser("task3", "demo");
+    taskService.addCandidateGroup("task3", "hr");
+
+    TaskQueryImpl baseQuery = (TaskQueryImpl) taskService.createTaskQuery()
+        .candidateUserAndGroup()
+        .taskCandidateUser("demo");
+
+    TaskQueryImpl extendingQuery = (TaskQueryImpl) taskService.createTaskQuery()
+        .taskCandidateGroupIn(Arrays.asList("sales", "it"));
+
+    // when
+    TaskQuery extendedQuery = baseQuery.extend(extendingQuery);
+    List<Task> tasks = extendedQuery.list();
+
+    // then
+    List<String> ids = tasks.stream()
+        .map(Task::getId)
+        .sorted()
+        .toList();
+
+    assertEquals(Arrays.asList("task1", "task2"), ids);
+  }
   // ---------------------- HELPER ------------------------------
 
   // make sure that time passes between two fast operations


### PR DESCRIPTION
### Summary
Adds support for combining candidateUser and candidateGroup* in TaskQuery using a new flag:
```
candidateUserAndGroup = true
```

### What changed?
Previously, using candidateUser together with candidateGroup* caused an exception. Now it is allowed only when `candidateUserAndGroup = true`. In that case, query uses AND semantics (both conditions must match)

### How to test
Java API
```java
taskService.createTaskQuery()
  .taskCandidateUser("john")
  .taskCandidateGroupIn(Arrays.asList("boss", "worker"))
  .candidateUserAndGroup(true)
  .list();
```
REST API
```
{
  "candidateUser": "john",
  "candidateGroups": ["boss", "worker"],
  "candidateUserAndGroup": true
}
```

**Expected**:
Returns tasks matching both user and group

### Backward compatibility
- Existing behavior is unchanged
- Using `candidateUser` together with `candidateGroup*` without the flag still throws an exception
- The new behavior is enabled only explicitly via `candidateUserAndGroup = true`
- 
### Why?
- Enables more precise filtering (user AND group)
- Keeps backward compatibility (old behavior unchanged without the flag)
