### PR TITLE
Replaced the current time-based UUID (v1) generation with random UUID v4

### DIFF
--- a/engine/src/main/java/org/eximeebpms/bpm/engine/impl/persistence/StrongUuidGenerator.java
+++ b/engine/src/main/java/org/eximeebpms/bpm/engine/impl/persistence/StrongUuidGenerator.java
@@ -16,39 +16,19 @@
  */
 package org.eximeebpms.bpm.engine.impl.persistence;
 
+import java.util.UUID;
+import lombok.NoArgsConstructor;
 import org.eximeebpms.bpm.engine.impl.cfg.IdGenerator;
 
-import com.fasterxml.uuid.EthernetAddress;
-import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedGenerator;
-
 /**
- * {@link IdGenerator} implementation based on the current time and the ethernet
- * address of the machine it is running on.
- * 
- * @author Daniel Meyer
+ * Secure random UUID (v4) based {@link IdGenerator}.
+ *
  */
+@NoArgsConstructor
 public class StrongUuidGenerator implements IdGenerator {
 
-  // different ProcessEngines on the same classloader share one generator.
-  protected static TimeBasedGenerator timeBasedGenerator;
-
-  public StrongUuidGenerator() {
-    ensureGeneratorInitialized();
-  }
-
-  protected void ensureGeneratorInitialized() {
-    if (timeBasedGenerator == null) {
-      synchronized (StrongUuidGenerator.class) {
-        if (timeBasedGenerator == null) {
-          timeBasedGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
-        }
-      }
-    }
-  }
-
   public String getNextId() {
-    return timeBasedGenerator.generate().toString();
+    return UUID.randomUUID().toString();
   }
 
 }

--- a/spring-boot-starter/starter/src/test/java/org/eximeebpms/bpm/spring/boot/starter/configuration/id/StrongUuidGeneratorIT.java
+++ b/spring-boot-starter/starter/src/test/java/org/eximeebpms/bpm/spring/boot/starter/configuration/id/StrongUuidGeneratorIT.java
@@ -44,14 +44,14 @@ public class StrongUuidGeneratorIT {
   private ProcessEngine processEngine;
 
   @Test
-  public void configured_idGenerator_is_uuid() throws Exception {
+  public void configured_idGenerator_is_uuid() {
     IdGenerator idGenerator = ((ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration()).getIdGenerator();
 
     assertThat(idGenerator).isOfAnyClassIn(StrongUuidGenerator.class);
   }
 
   @Test
-  public void nextId_is_uuid() throws Exception {
+  public void nextId_is_uuid() {
     assertThat(idGenerator.getNextId().split("-")).hasSize(5);
   }
 }

--- a/test-utils/assert/core/src/test/java/org/eximeebpms/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/eximeebpms/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
@@ -184,13 +184,13 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
     );
     // And
     Mocks.register("serviceTask_1", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_1").singleResult());
     // And
     Mocks.register("serviceTask_2", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_2").singleResult());
     // And
     Mocks.register("serviceTask_3", "someService");
-    execute(jobQuery().list().get(0));
+    execute(jobQuery().activityId("ServiceTask_3").singleResult());
     // Then
     expect(new Failure() {
       @Override

--- a/webapps/assembly/src/test/java/org/eximeebpms/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
+++ b/webapps/assembly/src/test/java/org/eximeebpms/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
@@ -144,8 +144,12 @@ public class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
     assertThat(result).isNotEmpty();
     assertThat(result).hasSize(2);
-    assertThat(result.get(0).getBusinessKey()).isEqualTo("firstCall:myBusinessKey");
-    assertThat(result.get(1).getBusinessKey()).isEqualTo("secondCall:myBusinessKey");
+    assertThat(result)
+        .extracting(ProcessInstanceDto::getBusinessKey)
+        .containsExactlyInAnyOrder(
+            "firstCall:myBusinessKey",
+            "secondCall:myBusinessKey"
+        );
   }
 
 


### PR DESCRIPTION
UUID v1 embeds timestamp and node information, making identifiers partially predictable and potentially exposing system metadata. This can enable resource enumeration and does not meet current security best practices (OWASP A04:2021 – Insecure Design).

UUID v4 is based on cryptographically strong randomness, does not leak metadata, and significantly improves resistance to ID guessing.