### PR TITLE
chore: migrate CI runner label to github-actions-runner-new

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+      time: "20:00"
+      timezone: "Europe/Warsaw"
     open-pull-requests-limit: 2
     # Delay patch-level PRs by 5 days after release so a compromised/broken
     # patch has time to get pulled or flagged upstream before we auto-merge
@@ -50,6 +52,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "20:00"
+      timezone: "Europe/Warsaw"
     open-pull-requests-limit: 2
     groups:
       github-actions:

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -66,8 +66,8 @@ run_build () {
   fi
 
   echo "ℹ️ Building $TEST_SUITE integration tests for distro $DISTRO with $DATABASE database using profiles: [${PROFILES[*]}]"
-  echo "./mvnw -DskipTests -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean install"
-  ./mvnw -DskipTests -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean install
+  echo "./mvnw -U -DskipTests -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean install"
+  ./mvnw -U -DskipTests -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean install
   if [[ $? -ne 0 ]]; then
     echo "❌ Error: Build failed"
     popd > /dev/null
@@ -113,8 +113,8 @@ run_tests () {
   esac
 
   echo "ℹ️ Running $TEST_SUITE integration tests for distro $DISTRO with $DATABASE database using profiles: [${PROFILES[*]}]"
-  echo "./mvnw -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean verify -f $QA_DIR"
-  ./mvnw -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean verify -f $QA_DIR
+  echo "./mvnw -U -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean verify -f $QA_DIR"
+  ./mvnw -U -Pdistro-ce,$(IFS=,; echo "${PROFILES[*]}") clean verify -f $QA_DIR
   if [[ $? -ne 0 ]]; then
     echo "❌ Error: Build failed"
     popd > /dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,43 @@ name: build
 on:
   pull_request:
     branches: [ "main" ]
+  # PRs opened by Dependabot cannot be dispatched to self-hosted runners
+  # under plain pull_request - GitHub queues them forever regardless of
+  # runner availability. pull_request_target runs with the trusted base-repo
+  # context instead, so self-hosted runners are allowed there. The `if`
+  # conditions on each job below restrict this path to Dependabot only, so
+  # human-authored PRs keep building under plain pull_request without
+  # base-repo secrets exposed to their (untrusted-until-reviewed) code.
+  pull_request_target:
+    branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # github.ref resolves to the base branch under pull_request_target, not a
+  # per-PR ref - grouping on it alone would put every Dependabot PR in the
+  # same concurrency group, cancelling each other's builds. Key on the PR
+  # number when there is one, and on event_name since pull_request and
+  # pull_request_target fire as two separate runs for the same PR.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 
 jobs:
   check:
     name: Check
-    runs-on: github-actions-runner-new
+    # GitHub-hosted: this job only diffs changed files, no build/network
+    # access needed - keep it off the scarce self-hosted pool that the real
+    # `build` job below still requires.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Skip the pull_request run for Dependabot (its actual build below needs
+    # pull_request_target - self-hosted runners aren't dispatched for
+    # Dependabot-triggered pull_request workflows) and skip the
+    # pull_request_target run for everyone else (their plain pull_request run
+    # above already covers it - avoids building PRs twice).
+    if: >-
+      !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') &&
+      !(github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]')
     outputs:
       skip_build: ${{ steps.verify.outputs.skip_build }}
     steps:
@@ -22,6 +47,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Get list of changed files
         id: verify
@@ -82,10 +108,39 @@ jobs:
           echo "Nothing to do. Exiting early."
           exit 0
 
+  hours-gate:
+    name: Business Hours Gate
+    # GitHub-hosted: only runs a `date` check, no build/network access needed.
+    # Always runs (unconditionally) so `build` below can depend on its output
+    # regardless of actor - a conditional job here would itself show as
+    # skipped for non-Dependabot runs, and a skipped `needs` job makes the
+    # dependent job skip too unless additionally guarded.
+    runs-on: ubuntu-latest
+    outputs:
+      business_hours: ${{ steps.gate.outputs.business_hours }}
+    steps:
+      - name: Determine if within business hours (Mon-Fri 07:00-18:00 Europe/Warsaw)
+        id: gate
+        run: |
+          DOW=$(TZ='Europe/Warsaw' date +%u)
+          HOUR=$((10#$(TZ='Europe/Warsaw' date +%H)))
+          if [[ "$DOW" -ge 1 && "$DOW" -le 5 && "$HOUR" -ge 7 && "$HOUR" -lt 18 ]]; then
+            echo "business_hours=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "business_hours=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build
-    needs: check
-    if: needs.check.outputs.skip_build == 'false'
+    needs: [check, hours-gate]
+    # Dependabot builds are deferred (this job just no-ops) during business
+    # hours to keep the scarce github-actions-runner-new pool free for human
+    # PRs; a scheduled workflow (dependabot-rerun.yml) automatically reruns
+    # any build left in this state once business hours end - no manual
+    # intervention needed. Human-authored PRs are never gated by this check.
+    if: >-
+      needs.check.outputs.skip_build == 'false' &&
+      !(github.actor == 'dependabot[bot]' && needs.hours-gate.outputs.business_hours == 'true')
     runs-on: github-actions-runner-new
     permissions:
       contents: read
@@ -97,6 +152,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up JDK
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,8 +150,14 @@ jobs:
       - name: Maven Build
         id: maven-build
         shell: bash
+        # -U on the first invocation only: the restore-keys fallback above can serve a
+        # cache blob saved before a just-bumped parent POM version was published to
+        # Nexus, and Maven's default 24h "don't recheck" policy then makes every build
+        # fail with a non-resolvable parent POM until the cache key changes again.
+        # -U forces the recheck without discarding the rest of the cache; later mvnw
+        # calls in this job reuse the now-correct local repo without needing it again.
         run: |
-          ./mvnw -B --settings ~/.m2-build/settings.xml verify
+          ./mvnw -B -U --settings ~/.m2-build/settings.xml verify
           ./mvnw --non-recursive --settings ~/.m2-build/settings.xml org.jacoco:jacoco-maven-plugin:report-aggregate
           ./mvnw --non-recursive --settings ~/.m2-build/settings.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=EximeeBPMS_eximeebpms -Dsonar.qualitygate.wait=true
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,11 @@ jobs:
           languages: java, javascript
 
       - name: Build (compile only, tests not needed for analysis)
-        run: ./mvnw -B --settings ~/.m2-codeql/settings.xml verify -DskipTests
+        # -U: see build.yml's Maven Build step - the restore-keys fallback above can
+        # serve a cache blob predating a parent POM version bump, and Maven's default
+        # 24h "don't recheck" policy would otherwise fail every build with a
+        # non-resolvable parent POM until the cache key changes again.
+        run: ./mvnw -B -U --settings ~/.m2-codeql/settings.xml verify -DskipTests
         env:
           MAVEN_OPTS: -Dmaven.repo.local=${{ github.workspace }}/.m2/repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (Java, JavaScript)
-    runs-on: self-hosted
+    runs-on: github-actions-runner-new
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/dependabot-rerun.yml
+++ b/.github/workflows/dependabot-rerun.yml
@@ -1,0 +1,51 @@
+name: Rerun deferred Dependabot builds
+
+# build.yml's hours-gate defers Dependabot builds (no-op skip) during
+# business hours (Mon-Fri 07:00-18:00 Europe/Warsaw) to keep the scarce
+# github-actions-runner-new pool free for human PRs. This workflow finds any
+# Dependabot PR whose latest build run ended up skipped and reruns it once
+# business hours are over, so those builds/auto-merges resume automatically.
+on:
+  schedule:
+    # 18:00 Europe/Warsaw is 16:00 UTC (CEST) or 17:00 UTC (CET) depending on
+    # DST - fire at both times rather than hardcoding one offset. The gate
+    # step below re-checks the real time before doing anything, so whichever
+    # of the two fires "early" for the current season is a harmless no-op.
+    - cron: '5 16 * * 1-5'
+    - cron: '5 17 * * 1-5'
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  rerun:
+    name: Rerun skipped Dependabot builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip unless actually past business hours (Europe/Warsaw)
+        id: gate
+        run: |
+          DOW=$(TZ='Europe/Warsaw' date +%u)
+          HOUR=$((10#$(TZ='Europe/Warsaw' date +%H)))
+          if [[ "$DOW" -ge 1 && "$DOW" -le 5 && "$HOUR" -ge 7 && "$HOUR" -lt 18 ]]; then
+            echo "Still business hours in Europe/Warsaw - nothing to do yet."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rerun any Dependabot build left skipped by the business-hours gate
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for pr_branch in $(gh pr list --repo "${{ github.repository }}" --author "app/dependabot" --state open --json headRefName --jq '.[].headRefName'); do
+            run_id=$(gh run list --repo "${{ github.repository }}" --branch "$pr_branch" --workflow=build.yml --limit 1 --json databaseId,conclusion --jq '.[0] | select(.conclusion=="skipped") | .databaseId')
+            if [[ -n "$run_id" ]]; then
+              echo "Rerunning skipped build for $pr_branch (run $run_id)"
+              gh run rerun "$run_id" --repo "${{ github.repository }}"
+            fi
+          done

--- a/.github/workflows/update-sbom.yml
+++ b/.github/workflows/update-sbom.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   update-sbom:
     name: Generate and commit SBOM
-    runs-on: self-hosted
+    runs-on: github-actions-runner-new
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(join(github.event.commits.*.message, ' '), 'deps')

--- a/.github/workflows/update-sbom.yml
+++ b/.github/workflows/update-sbom.yml
@@ -68,8 +68,12 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Generate Maven SBOM (CycloneDX)
+        # -U: see build.yml's Maven Build step - the restore-keys fallback above can
+        # serve a cache blob predating a parent POM version bump, and Maven's default
+        # 24h "don't recheck" policy would otherwise fail every build with a
+        # non-resolvable parent POM until the cache key changes again.
         run: |
-          ./mvnw -B --settings ~/.m2-sbom/settings.xml org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom \
+          ./mvnw -B -U --settings ~/.m2-sbom/settings.xml org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom \
             -DoutputFormat=json \
             -DoutputName=eximeebpms-bom
         env:


### PR DESCRIPTION
## Summary
- The self-hosted runner is being decommissioned org-wide.
- Updates `runs-on: self-hosted` to `runs-on: github-actions-runner-new` in `codeql.yml` and `update-sbom.yml` (other workflows in this repo already use the new label).

## Test plan
- CI on this PR runs the affected jobs on `github-actions-runner-new`.